### PR TITLE
Add contributing necessities

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+  Thanks for making a pull request! 
+  
+  Before submitting, please read our contributing guidelines:
+  https://github.com/unmock/json-schema-strictly-typed#contributing
+
+  Have any questions? 
+  Feel free to ask in this PR and one of our maintainers will be happy to help 🙌
+-->
+
+Fixes #<issue number>
+
+## Description
+
+<!-- Write a brief description of the changes introduced by this PR -->
+
+## How to test 
+
+<!-- What steps can we take to test that your code is working properly -->

--- a/README.md
+++ b/README.md
@@ -62,5 +62,3 @@ detaling how to contribute. Meanwhile, there is plenty of feature that haven't b
 
 
 Please note that this project is governed by the [Unmock Community Code of Conduct](https://github.com/unmock/code-of-conduct). By participating in this project, you agree to abide by its terms.
-
-Please note that this project is governed by the [Unmock Community Code of Conduct](https://github.com/unmock/code-of-conduct). By participating in this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Additionally, top-level versions of all of these are available by adding `TopLev
 ## Contributing
 
 Thanks for wanting to contribute! We will soon have a contributing page
-detaling how to contribute. Meanwhile, there is plenty of features that haven't been implemented yet. Please check out our [open issues](https://github.com/unmock/json-schema-strictly-typed/issues). We'd really appreciate your help!
+detaling how to contribute. Meanwhile, there are plenty of features that haven't been implemented yet. Please check out our [open issues](https://github.com/unmock/json-schema-strictly-typed/issues). We'd really appreciate your help!
 
 
 Please note that this project is governed by the [Unmock Community Code of Conduct](https://github.com/unmock/code-of-conduct). By participating in this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Here are all of the types in the API.  Some of them also have sub-types for usef
 
 Additionally, top-level versions of all of these are available by adding `TopLevel` to the definition. Top-level JSON Schema objects contain optional fields like `$id`, `$schema` and `definitions`.
 
-## Todo
+## Contributing
 
-There is plenty of stuff that is not implemented yet.  I'd really appreciate your help!
+Thanks for wanting to contribute! We will soon have a contributing page
+detaling how to contribute. Meanwhile, there is plenty of feature that haven't been implemented yet. Please check out our [open issues](https://github.com/unmock/json-schema-strictly-typed/issues). We'd really appreciate your help!
 
-* finish implementing the JSON Schema 7 Specification
-* add various schema extensions
-* use XOR combinator instead of `|` for types to avoid nonsense unoins
+
+Please note that this project is governed by the [Unmock Community Code of Conduct](https://github.com/unmock/code-of-conduct). By participating in this project, you agree to abide by its terms.
 
 Please note that this project is governed by the [Unmock Community Code of Conduct](https://github.com/unmock/code-of-conduct). By participating in this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Additionally, top-level versions of all of these are available by adding `TopLev
 ## Contributing
 
 Thanks for wanting to contribute! We will soon have a contributing page
-detaling how to contribute. Meanwhile, there is plenty of feature that haven't been implemented yet. Please check out our [open issues](https://github.com/unmock/json-schema-strictly-typed/issues). We'd really appreciate your help!
+detaling how to contribute. Meanwhile, there is plenty of features that haven't been implemented yet. Please check out our [open issues](https://github.com/unmock/json-schema-strictly-typed/issues). We'd really appreciate your help!
 
 
 Please note that this project is governed by the [Unmock Community Code of Conduct](https://github.com/unmock/code-of-conduct). By participating in this project, you agree to abide by its terms.


### PR DESCRIPTION
I've been adding contributing guides and pull request templates to each repo, but I wanted to check before adding them to this one. I've also taken the original TODO section list and turned them into open issues with a `help wanted` tag.